### PR TITLE
fix(service): there could be chances that JDPay's location is different.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ h5_pay
 JdPay::Service.h5_pay(params, options = {})
 ```
 
+### **Important notice for `need_redirect_url`**
+Due to unstable redirect url in JDPay's side, we manually organize the redirect url on our own. Please check method [get_redirect_url](https://github.com/genkin-he/jdpay/blob/master/lib/jd_pay/service.rb#L194-L209) for more details. **If any unexpected response is met, please fill an issue.**
+
 ### 交易查询接口
 #### Name && Description
 > 交易查询接口是为了处理商户服务器长时间没有接收到支付结果的情况设计的。一般情况，支付结果会通过前端同步返回和京东支付服务器的异步通知发送到商户服务。但是为避免特殊情况商户服务器仍然没有接收到支付结果，这时候商户服务可以通过主动查询交易结果的接口查询支付状态。

--- a/lib/jd_pay/service.rb
+++ b/lib/jd_pay/service.rb
@@ -12,8 +12,8 @@ module JdPay
     QRCODE_PAY_URL = 'https://paygate.jd.com/service/fkmPay'
     USER_RELATION_URL = 'https://paygate.jd.com/service/getUserRelation'
     CANCEL_USER_URL = 'https://paygate.jd.com/service/cancelUserRelation'
-    WEB_PAY_BASE_URL = 'https://wepay.jd.com/jdpay'
-    H5_PAY_BASE_URL = 'https://h5pay.jd.com/jdpay'
+    WEB_PAY_BASE_URL = 'https://wepay.jd.com/jdpay/payCashier'
+    H5_PAY_BASE_URL = 'https://h5pay.jd.com/jdpay/payCashier'
 
     class << self
       # the difference between pc and h5 is just request url
@@ -205,7 +205,7 @@ module JdPay
         # Examples:
         # For h5pay: https://h5pay.jd.com/jdpay/payCashier?tradeNum=xxx&orderId=xxx&key=xxx
         # For webpay: payCashier?tradeNum=xxx&ourTradeNum=xxx&key=xxx
-        resp['location'].include?(base_url) ? resp['location'] : "#{base_url}/#{resp['location']}"
+        resp['location'].include?(base_url) ? resp['location'] : "#{base_url}?#{resp['location'].split('?')[1]}"
       end
     end
   end


### PR DESCRIPTION
During the tests in production env, we got a weird redirection URL, which happened from time to time: `/jdpay/payCashier?tradeNum=xxx&ourTradeNum=xxx&key=xxx`. This caused our response being `https://h5pay.jd.com/jdpay/jdpay/payCashier?tradeNum=xxx&ourTradeNum=xxx&key=xxx`, although JD's developer denied that there could be any type of this response. So we decided to splitting params and make the full url on our own.